### PR TITLE
Fix logger context and use orchestrator token

### DIFF
--- a/lib/actions/delete.js
+++ b/lib/actions/delete.js
@@ -1,7 +1,8 @@
 const { SftpDelete } = require('../utils/deleteUtil');
 const Sftp = require('../Sftp');
 
-async function process(msg, cfg, snapshot = {}) {
+async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();
   const deleteAction = new SftpDelete(this.logger, sftpClient);

--- a/lib/actions/delete.js
+++ b/lib/actions/delete.js
@@ -2,6 +2,7 @@ const { SftpDelete } = require('../utils/deleteUtil');
 const Sftp = require('../Sftp');
 
 async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();

--- a/lib/actions/lookupObject.js
+++ b/lib/actions/lookupObject.js
@@ -2,6 +2,7 @@ const { SftpLookupObject } = require('../utils/lookupObjectUtil');
 const Sftp = require('../Sftp');
 
 async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();

--- a/lib/actions/lookupObject.js
+++ b/lib/actions/lookupObject.js
@@ -1,7 +1,8 @@
 const { SftpLookupObject } = require('../utils/lookupObjectUtil');
 const Sftp = require('../Sftp');
 
-async function process(msg, cfg, snapshot = {}) {
+async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();
   const lookupObjectAction = new SftpLookupObject(this.logger, sftpClient);

--- a/lib/actions/lookupObjects.js
+++ b/lib/actions/lookupObjects.js
@@ -222,7 +222,8 @@ async function shutdown(cfg, data) {
   await sftpClient.end();
 }
 
-async function process(msg, cfg, snapshot = {}) {
+async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   try {
     const numSearchTerms = parseInt(cfg.numSearchTerms || 0, 10);
     if (!isNumberInInterval(numSearchTerms, 0, 99)) {

--- a/lib/actions/moveFile.js
+++ b/lib/actions/moveFile.js
@@ -1,6 +1,7 @@
 const Sftp = require('../Sftp');
 
-async function process(msg, cfg) {
+async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();
   this.logger.info('Start moving file...');

--- a/lib/actions/moveFile.js
+++ b/lib/actions/moveFile.js
@@ -1,6 +1,8 @@
 const Sftp = require('../Sftp');
 
+// eslint-disable-next-line no-unused-vars
 async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();

--- a/lib/actions/upload.js
+++ b/lib/actions/upload.js
@@ -10,7 +10,9 @@ const { ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('../constants'
  * @param msg incoming message object that contains ``data`` with payload
  * @param cfg configuration that is account information and configuration field values
  */
+// eslint-disable-next-line no-unused-vars
 exports.process = async function processAction(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   this.logger.info('Connecting to sftp server...');
   const sftp = new Sftp(this.logger, cfg);

--- a/lib/actions/upload.js
+++ b/lib/actions/upload.js
@@ -10,7 +10,8 @@ const { ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('../constants'
  * @param msg incoming message object that contains ``data`` with payload
  * @param cfg configuration that is account information and configuration field values
  */
-exports.process = async function processAction(msg, cfg) {
+exports.process = async function processAction(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   this.logger.info('Connecting to sftp server...');
   const sftp = new Sftp(this.logger, cfg);
   await sftp.connect();

--- a/lib/actions/upsertFile.js
+++ b/lib/actions/upsertFile.js
@@ -7,7 +7,8 @@ const Sftp = require('../Sftp');
  * @param msg incoming message object that contains ``data`` with payload
  * @param cfg configuration that is account information and configuration field values
  */
-exports.process = async function processAction(msg, cfg, snapshot = {}) {
+exports.process = async function processAction(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();
 

--- a/lib/actions/upsertFile.js
+++ b/lib/actions/upsertFile.js
@@ -8,6 +8,7 @@ const Sftp = require('../Sftp');
  * @param cfg configuration that is account information and configuration field values
  */
 exports.process = async function processAction(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();

--- a/lib/attachmentProcessor.js
+++ b/lib/attachmentProcessor.js
@@ -38,7 +38,7 @@ class AttachmentProcessor {
   }
 
   async uploadAttachment(body, mimeType) {
-    const putUrl = await AttachmentProcessor.preparePutUrl(this.attachmentService);
+    const putUrl = await this.preparePutUrl(this.attachmentService);
     const ax = axios.create();
     AttachmentProcessor.addRetryCountInterceptorToAxios(ax);
 
@@ -60,7 +60,7 @@ class AttachmentProcessor {
     return ax(axConfig);
   }
 
-  static async preparePutUrl(attachmentService) {
+  async preparePutUrl(attachmentService) {
     const service = attachmentService || ATTACHMENT_STORAGE_SERVICE_BASE_URL;
     const signedUrl = `${service}/objects/${uuid.v4()}`;
 

--- a/lib/triggers/polling.js
+++ b/lib/triggers/polling.js
@@ -1,7 +1,8 @@
 const { SftpPolling } = require('../utils/pollingUtil');
 const Sftp = require('../Sftp');
 
-async function process(msg, cfg, snapshot = {}) {
+async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();
   const pollingTrigger = new SftpPolling(this.logger, this, sftpClient, cfg);

--- a/lib/triggers/polling.js
+++ b/lib/triggers/polling.js
@@ -2,6 +2,7 @@ const { SftpPolling } = require('../utils/pollingUtil');
 const Sftp = require('../Sftp');
 
 async function process(msg, cfg, snapshot = {}, headers, tokenData = {}) {
+  // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftpClient = new Sftp(this.logger, cfg);
   await sftpClient.connect();

--- a/lib/triggers/read.js
+++ b/lib/triggers/read.js
@@ -63,6 +63,7 @@ async function readFiles(cfg, sftp, dir, files) {
 }
 
 exports.process = async function process(msg, cfg, snapshot, headers, tokenData = {}) {
+  // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftp = new Sftp(this.logger, cfg);
   await sftp.connect();

--- a/lib/triggers/read.js
+++ b/lib/triggers/read.js
@@ -62,7 +62,8 @@ async function readFiles(cfg, sftp, dir, files) {
   }
 }
 
-exports.process = async function process(msg, cfg) {
+exports.process = async function process(msg, cfg, snapshot, headers, tokenData = {}) {
+  cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const sftp = new Sftp(this.logger, cfg);
   await sftp.connect();
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "pretest": "eslint spec spec-integration lib --fix",
     "test": "LOG_LEVEL=trace;mocha spec --recursive --timeout 50000",
     "integration-test": "LOG_LEVEL=trace;LOG_OUTPUT_MODE=short mocha spec-integration/* --timeout 50000",
-    "build:docker": "docker build --pull --rm -f \"Dockerfile\" -t sftp-component:latest ."
+    "build:docker": "docker build --pull --rm -f \"Dockerfile\" -t sftp-component:latest .",
+    "lint": "eslint lib"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes:
- changes `AttachmentProcessor.preparePutUrl()` to not be `static` method, fixing context error when invoked
- automatically uses component-orchestrator token for Attachment Storage Service auth unless `token` is supplied by config

Closes #16 
Closes #15 

Note:
The component-orchestrator token is passed to later steps by setting `cfg.token` if it is not already set. This modifies a parameter in violation of the current linting guidelines and may not be ideal. Other approaches are possible but would require updating more code across the 8 `process()` functions in `/actions` and `/triggers`.