### PR TITLE
Error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Also please pay attention that the field `Password` should be empty in this case
 The following configuration fields are available:
 * **Directory**: The directory of the files to read from.
 * **Pattern**: Optional regex pattern for file names. If no pattern is given, no matching is done.
+* **dontThrowErrorFlag**: If set, component will emit message to the next step with the `errorName`, `errorMessage`, and `errorStack`
 
 After a file is found:
  * It is moved to the (hidden) directory `.oih_processed`
@@ -154,6 +155,8 @@ The following configuration fields are available:
 Input metadata:
 
 - **Filename**: Custom name for uploaded file.
+- **enableRebound**: If set, component will retry upon write errors
+- **dontThrowErrorFlag**: If set, component will emit message to the next step with the `errorName`, `errorMessage`, and `errorStack`
 
 Notes:
 * Uploaded file name will get filename of income file if new `Filename` doesn't provided
@@ -170,6 +173,8 @@ The following configuration fields are available:
   - **Throw an Error**: Does not write data to the file and the component produces an error
   - **Overwrite the File**: Replace the existing file contents with the contents of the attachment stored in the platform.
   - **Append the File Contents**: Adds the contents of the attachment stored in the platform to the end of the file. No intermediate characters (e.g. newlines or spaces) will be added.
+- **enableRebound**: If set, component will retry upon write errors
+- **dontThrowErrorFlag**: If set, component will emit message to the next step with the `errorName`, `errorMessage`, and `errorStack`
 
 * Note: If the filename provided contains directories that do not exist, those directories will be created.
 

--- a/lib/actions/upload.js
+++ b/lib/actions/upload.js
@@ -1,8 +1,10 @@
 /* eslint-disable no-await-in-loop */
+const { wrapper } = require('@blendededge/ferryman-extensions');
 const path = require('path');
 const { AttachmentProcessor } = require('@blendededge/ferryman-extensions');
 const Sftp = require('../Sftp');
 const { ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('../constants');
+const handleError = require('../utils/handleErrors');
 
 /**
  * This method will be called from Open Integration Hub platform providing following data
@@ -14,51 +16,56 @@ const { ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('../constants'
 exports.process = async function processAction(msg, cfg, snapshot = {}, headers, tokenData = {}) {
   // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
-  this.logger.info('Connecting to sftp server...');
-  const sftp = new Sftp(this.logger, cfg);
-  await sftp.connect();
+  const wrapped = wrapper(this, msg, cfg, snapshot);
+  try {
+    wrapped.logger.info('Connecting to sftp server...');
+    const sftp = new Sftp(wrapped.logger, cfg);
+    await sftp.connect();
 
-  const result = {
-    results: [],
-  };
-  const dir = cfg.directory || '/';
-  // eslint-disable-next-line no-use-before-define
-  const filename = prepareFilename(msg);
-  this.logger.debug(`Prepared filename: ${filename}`);
-
-  const isExists = await sftp.exists(dir);
-  if (!isExists) {
-    await sftp.mkdir(dir, true);
-  }
-
-  this.logger.info(`Found ${Object.keys(msg.attachments).length} attachments`);
-
-  // eslint-disable-next-line no-param-reassign
-  cfg.attachmentServiceUrl = cfg.attachmentServiceUrl ? cfg.attachmentServiceUrl : ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL;
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const key of Object.keys(msg.attachments)) {
-    const attachment = msg.attachments[key];
-    const cur = await sftp.cwd();
+    const result = {
+      results: [],
+    };
+    const dir = cfg.directory || '/';
     // eslint-disable-next-line no-use-before-define
-    const keyName = prepareKeyname(key, filename, msg);
-    const targetPath = (cur.charAt(0) === '/') ? path.posix.resolve(dir, keyName) : path.resolve(dir, keyName);
-    this.logger.debug('Writing attachment to targetPath');
+    const filename = prepareFilename(msg);
+    wrapped.logger.debug(`Prepared filename: ${filename}`);
 
-    this.logger.debug('Getting attachment...');
-    const file = await new AttachmentProcessor(this, cfg.token, cfg.attachmentServiceUrl).getAttachment(attachment.url, 'stream');
-    this.logger.debug('Uploading attachment to targetPath');
-    await sftp.put(file.data, targetPath, { encoding: null });
-    this.logger.info('Attachment uploaded successfully');
+    const isExists = await sftp.exists(dir);
+    if (!isExists) {
+      await sftp.mkdir(dir, true);
+    }
 
-    result.results.push({
-      attachment: key,
-      uploadedOn: new Date().toISOString(),
-      path: targetPath,
-    });
+    wrapped.logger.info(`Found ${Object.keys(msg.attachments).length} attachments`);
+
+    // eslint-disable-next-line no-param-reassign
+    cfg.attachmentServiceUrl = cfg.attachmentServiceUrl ? cfg.attachmentServiceUrl : ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL;
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key of Object.keys(msg.attachments)) {
+      const attachment = msg.attachments[key];
+      const cur = await sftp.cwd();
+      // eslint-disable-next-line no-use-before-define
+      const keyName = prepareKeyname(key, filename, msg);
+      const targetPath = (cur.charAt(0) === '/') ? path.posix.resolve(dir, keyName) : path.resolve(dir, keyName);
+      wrapped.logger.debug('Writing attachment to targetPath');
+
+      wrapped.logger.debug('Getting attachment...');
+      const file = await new AttachmentProcessor(wrapped, cfg.token, cfg.attachmentServiceUrl).getAttachment(attachment.url, 'stream');
+      wrapped.logger.debug('Uploading attachment to targetPath');
+      await sftp.put(file.data, targetPath, { encoding: null });
+      wrapped.logger.info('Attachment uploaded successfully');
+
+      result.results.push({
+        attachment: key,
+        uploadedOn: new Date().toISOString(),
+        path: targetPath,
+      });
+    }
+    await sftp.end();
+    return { data: result, attachments: {}, metadata: {} };
+  } catch (e) {
+    return handleError(wrapped, e, cfg, 'write');
   }
-  await sftp.end();
-  return { data: result, attachments: {}, metadata: {} };
 };
 
 function prepareFilename(msg) {

--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -6,6 +6,7 @@ const { AttachmentProcessor } = require('@blendededge/ferryman-extensions');
 const { unixTimeToIsoDate, getContentType } = require('./utils/utils');
 const { MAX_FILE_SIZE, ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('./constants');
 
+// eslint-disable-next-line
 async function addAttachment(msg, cfg, name, stream, contentLength) {
   try {
     if (contentLength > MAX_FILE_SIZE) {
@@ -18,6 +19,9 @@ async function addAttachment(msg, cfg, name, stream, contentLength) {
       url: result.config.url,
       size: contentLength,
     };
+    console.log('what does result look like?', result);
+    console.log('what does msg look like here?', msg);
+    return msg;
   } catch (e) {
     this.emit('error', e);
   }

--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -19,9 +19,6 @@ async function addAttachment(msg, cfg, name, stream, contentLength) {
       url: result.config.url,
       size: contentLength,
     };
-    console.log('what does result look like?', result);
-    console.log('what does msg look like here?', msg);
-    return msg;
   } catch (e) {
     this.emit('error', e);
   }

--- a/lib/triggers/read.js
+++ b/lib/triggers/read.js
@@ -3,6 +3,7 @@ const { Readable } = require('stream');
 const Sftp = require('../Sftp');
 const attachments = require('../attachments');
 const { MAX_FILE_SIZE, ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('../constants');
+const handleError = require('../utils/handleErrors');
 
 const PROCESSED_FOLDER_NAME = '.oih_processed';
 
@@ -40,7 +41,6 @@ async function createMessageForFile(cfg, sftp, dir, file) {
     attachments: {},
     metadata: {},
   };
-
   this.logger.info('Moving file into staging folder');
   await moveFile.call(this, sftp, dir, fileName, newFileName);
   this.logger.info('Reading file into read stream');
@@ -48,7 +48,10 @@ async function createMessageForFile(cfg, sftp, dir, file) {
   const readStream = new Readable();
   readStream.push(buffer);
   readStream.push(null);
-  await attachments.addAttachment.call(this, msg, cfg, fileName, readStream, file.size);
+  const attachment = await attachments.addAttachment.call(this, msg, cfg, fileName, readStream, file.size);
+  msg.attachments = attachment;
+  console.log(attachment, 'attachment');
+  console.log('msg here?', JSON.stringify(msg));
   return msg;
 }
 
@@ -58,31 +61,36 @@ async function readFiles(cfg, sftp, dir, files) {
     this.logger.info('Processing file');
     // eslint-disable-next-line no-await-in-loop
     const msg = await createMessageForFile.call(this, cfg, sftp, dir, file);
+    console.log(JSON.stringify(msg));
     // eslint-disable-next-line no-await-in-loop
     await this.emit('data', msg);
   }
 }
-
+// eslint-disable-next-line
 exports.process = async function process(msg, cfg, snapshot, headers, tokenData = {}) {
   // eslint-disable-next-line no-param-reassign
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const wrapped = wrapper(this, msg, cfg, {});
-  const sftp = new Sftp(this.logger, cfg);
-  await sftp.connect();
+  try {
+    const sftp = new Sftp(this.logger, cfg);
+    await sftp.connect();
+    let dir = cfg.directory || '/';
+    if (dir.charAt(0) !== '/') {
+      dir = `/${dir}`;
+    }
 
-  let dir = cfg.directory || '/';
-  if (dir.charAt(0) !== '/') {
-    dir = `/${dir}`;
+    this.logger.info('Finding files in directory');
+    const list = await sftp.list(dir, new RegExp(cfg.pattern || ''));
+    this.logger.debug('Found files: %s', Object.keys(list.filter((item) => item.type === '-')).length);
+    const files = await filterFilesByPattern(list, cfg.pattern);
+    this.logger.debug('Files that match filter: %s', Object.keys(files.map((file) => file.name)).length);
+
+    // eslint-disable-next-line no-param-reassign
+    cfg.attachmentServiceUrl = cfg.attachmentServiceUrl ? cfg.attachmentServiceUrl : ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL;
+    await readFiles.call(wrapped, cfg, sftp, dir, files);
+    await sftp.end();
+    await wrapped.emit('end');
+  } catch (e) {
+    return handleError(wrapped, e, cfg);
   }
-
-  this.logger.info('Finding files in directory');
-  const list = await sftp.list(dir, new RegExp(cfg.pattern || ''));
-  this.logger.debug('Found files: %s', Object.keys(list.filter((item) => item.type === '-')).length);
-  const files = await filterFilesByPattern(list, cfg.pattern);
-  this.logger.debug('Files that match filter: %s', Object.keys(files.map((file) => file.name)).length);
-
-  // eslint-disable-next-line no-param-reassign
-  cfg.attachmentServiceUrl = cfg.attachmentServiceUrl ? cfg.attachmentServiceUrl : ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL;
-  await readFiles.call(wrapped, cfg, sftp, dir, files);
-  await sftp.end();
 };

--- a/lib/triggers/read.js
+++ b/lib/triggers/read.js
@@ -48,10 +48,7 @@ async function createMessageForFile(cfg, sftp, dir, file) {
   const readStream = new Readable();
   readStream.push(buffer);
   readStream.push(null);
-  const attachment = await attachments.addAttachment.call(this, msg, cfg, fileName, readStream, file.size);
-  msg.attachments = attachment;
-  console.log(attachment, 'attachment');
-  console.log('msg here?', JSON.stringify(msg));
+  await attachments.addAttachment.call(this, msg, cfg, fileName, readStream, file.size);
   return msg;
 }
 
@@ -61,7 +58,6 @@ async function readFiles(cfg, sftp, dir, files) {
     this.logger.info('Processing file');
     // eslint-disable-next-line no-await-in-loop
     const msg = await createMessageForFile.call(this, cfg, sftp, dir, file);
-    console.log(JSON.stringify(msg));
     // eslint-disable-next-line no-await-in-loop
     await this.emit('data', msg);
   }

--- a/lib/utils/handleErrors.js
+++ b/lib/utils/handleErrors.js
@@ -14,7 +14,6 @@ async function handleError(emitter, error, cfg, writeAction) {
     await emitter.emit('data', { data: output });
   } else {
     await emitter.emit('error', error.message);
-    throw Error(error.message);
   }
 }
 

--- a/lib/utils/handleErrors.js
+++ b/lib/utils/handleErrors.js
@@ -1,0 +1,21 @@
+// eslint-disable-next-line
+async function handleError(emitter, error, cfg, writeAction) {
+  if (cfg.enableRebound && writeAction) {
+    emitter.logger.info('Component error: %o', JSON.stringify(error));
+    emitter.logger.info('Starting rebound');
+    await emitter.emit('rebound', error.message);
+  } else if (cfg.dontThrowErrorFlag) {
+    const output = {
+      errorName: error.name,
+      errorStack: error.stack,
+      errorMessage: error.message,
+    };
+    emitter.logger.debug('Component output: %o', output);
+    await emitter.emit('data', { data: output });
+  } else {
+    await emitter.emit('error', error.message);
+    throw Error(error.message);
+  }
+}
+
+module.exports = handleError;

--- a/lib/utils/handleErrors.js
+++ b/lib/utils/handleErrors.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line
 async function handleError(emitter, error, cfg, writeAction) {
   if (cfg.enableRebound && writeAction) {
-    emitter.logger.info('Component error: %o', JSON.stringify(error));
+    emitter.logger.info('Component error: %o', error);
     emitter.logger.info('Starting rebound');
     await emitter.emit('rebound', error.message);
   } else if (cfg.dontThrowErrorFlag) {

--- a/lib/utils/handleErrors.js
+++ b/lib/utils/handleErrors.js
@@ -14,6 +14,7 @@ async function handleError(emitter, error, cfg, writeAction) {
     await emitter.emit('data', { data: output });
   } else {
     await emitter.emit('error', error.message);
+    throw Error(error.message);
   }
 }
 

--- a/spec/triggers/read.spec.js
+++ b/spec/triggers/read.spec.js
@@ -23,6 +23,10 @@ describe('SFTP test - read trigger', () => {
     directory: 'www/test',
   };
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('Failed to connect', async () => {
     const sftpClientConnectStub = sinon.stub(Sftp.prototype, 'connect').throws(new Error('Connection failed'));
 
@@ -65,7 +69,6 @@ describe('SFTP test - read trigger', () => {
 
     await trigger.process.call(self, {}, cfg);
 
-    expect(self.emit.called).to.be.equal(false);
     expect(sftpClientEndStub.calledOnce).to.be.equal(true);
     expect(sftpClientListStub.calledOnce).to.be.equal(true);
     expect(sftpClientConnectStub.calledOnce).to.be.equal(true);
@@ -95,7 +98,6 @@ describe('SFTP test - read trigger', () => {
 
     await trigger.process.call(self, {}, { ...cfg, pattern: 'aaa' });
 
-    expect(self.emit.called).to.be.equal(false);
     expect(sftpClientConnectStub.calledOnce).to.be.equal(true);
     sftpClientEndStub.restore();
     sftpClientConnectStub.restore();
@@ -123,7 +125,6 @@ describe('SFTP test - read trigger', () => {
 
     await trigger.process.call(self, {}, cfg);
 
-    expect(self.emit.called).to.be.equal(false);
     expect(sftpClientConnectStub.calledOnce).to.be.equal(true);
     expect(sftpClientEndStub.calledOnce).to.be.equal(true);
     expect(sftpClientListStub.calledOnce).to.be.equal(true);
@@ -157,9 +158,7 @@ describe('SFTP test - read trigger', () => {
 
     await trigger.process.call(self, {}, cfg);
 
-    expect(self.emit.calledOnce).to.be.equal(true);
-    expect(self.emit.getCall(0).args[0]).to.be.equal('data');
-    expect(self.emit.getCall(0).args[1].data).to.be.deep.equal({
+    expect(self.emit.getCall(6).args[1].data).to.be.deep.equal({
       filename: '1.txt',
       size: 7,
     });


### PR DESCRIPTION
** Still waiting to ensure rebound functionality is working **

This change adds two fields to the SFTP configuration. `dontThrowErrorFlag` is available on `read` and `upload`. `enableRebound` is available on `upload`. 