### PR TITLE
Add secret service

### DIFF
--- a/lib/Sftp.js
+++ b/lib/Sftp.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 const Client = require('ssh2-sftp-client');
+const { authTypes } = require('./utils/retrieveSecrets');
 const ip = require('./ip');
 
 module.exports = class Sftp {
@@ -24,22 +25,30 @@ module.exports = class Sftp {
 
   async createConnectionOptions() {
     const {
-      host, port = 22, username, password, privateKey,
+      host, port = 22, username, password, privateKey, auth,
     } = this._cfg;
     await ip.resolve(host);
     this.logger.debug('IP successfully resolved');
     const params = {
       host,
       port,
-      username,
       retries: 1,
       readyTimeout: 10000,
     };
-    if (password) {
+
+    if (auth && auth.type === authTypes.API_KEY) {
+      params.privateKey = auth.apiKey.headerValue;
+    } else if (auth && auth.type === authTypes.BASIC) {
+      params.username = auth.basic.username;
+      params.password = auth.basic.password;
+    } else if (password) {
+      params.username = username;
       params.password = password;
     } else if (privateKey) {
+      params.username = username;
       params.privateKey = privateKey;
     }
+
     return params;
   }
 

--- a/lib/actions/upload.js
+++ b/lib/actions/upload.js
@@ -5,6 +5,7 @@ const { AttachmentProcessor } = require('@blendededge/ferryman-extensions');
 const Sftp = require('../Sftp');
 const { ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('../constants');
 const handleError = require('../utils/handleErrors');
+const { getAuthFromSecretConfig } = require('../utils/retrieveSecrets');
 
 /**
  * This method will be called from Open Integration Hub platform providing following data
@@ -19,7 +20,8 @@ exports.process = async function processAction(msg, cfg, snapshot = {}, headers,
   const wrapped = wrapper(this, msg, cfg, snapshot);
   try {
     wrapped.logger.info('Connecting to sftp server...');
-    const sftp = new Sftp(wrapped.logger, cfg);
+    const cfgWithSecret = getAuthFromSecretConfig(cfg, wrapped.logger);
+    const sftp = new Sftp(wrapped.logger, cfgWithSecret);
     await sftp.connect();
 
     const result = {

--- a/lib/triggers/read.js
+++ b/lib/triggers/read.js
@@ -4,6 +4,7 @@ const Sftp = require('../Sftp');
 const attachments = require('../attachments');
 const { MAX_FILE_SIZE, ELASTICIO_ATTACHMENT_STORAGE_SERVICE_BASE_URL } = require('../constants');
 const handleError = require('../utils/handleErrors');
+const { getAuthFromSecretConfig } = require('../utils/retrieveSecrets');
 
 const PROCESSED_FOLDER_NAME = '.oih_processed';
 
@@ -68,7 +69,8 @@ exports.process = async function process(msg, cfg, snapshot, headers, tokenData 
   cfg.token = cfg.token ? cfg.token : tokenData.apiKey;
   const wrapped = wrapper(this, msg, cfg, {});
   try {
-    const sftp = new Sftp(this.logger, cfg);
+    const cfgWithSecret = getAuthFromSecretConfig(cfg, wrapped.logger);
+    const sftp = new Sftp(wrapped.logger, cfgWithSecret);
     await sftp.connect();
     let dir = cfg.directory || '/';
     if (dir.charAt(0) !== '/') {

--- a/lib/utils/retrieveSecrets.js
+++ b/lib/utils/retrieveSecrets.js
@@ -1,0 +1,45 @@
+const { transform } = require('@openintegrationhub/ferryman');
+
+const authTypes = {
+  NO_AUTH: 'No Auth',
+  BASIC: 'Basic Auth',
+  API_KEY: 'API Key Auth',
+};
+
+function getAuthFromSecretConfig(cfg, logger) {
+  const {
+    username, passphrase, key, headerName, secretAuthTransform,
+  } = cfg;
+  const returnConfig = { ...cfg };
+  const { auth = {} } = returnConfig;
+
+  // Use JSONata to populate cfg.auth object, works for all types but especially helpful for the MIXED type
+  if (secretAuthTransform) {
+    returnConfig.auth = transform(cfg, { customMapping: secretAuthTransform });
+    logger.debug(`helpers.getAuthFromSecretConfig: after transforming auth config: ${JSON.stringify(returnConfig)}`);
+    return returnConfig;
+  }
+  // Found username and password, authenticate with basic authentication
+  if (username && passphrase) {
+    auth.basic = auth.basic ? auth.basic : {};
+    auth.type = authTypes.BASIC;
+    auth.basic.username = username;
+    auth.basic.password = passphrase;
+  }
+  // Found API_KEY type
+  if (key) {
+    auth.type = authTypes.API_KEY;
+    auth.apiKey = auth.apiKey ? auth.apiKey : {};
+    auth.apiKey.headerName = headerName;
+    auth.apiKey.headerValue = key;
+  }
+
+  returnConfig.auth = auth;
+  logger.debug(`helpers.getAuthFromSecretConfig: config object is now: ${JSON.stringify(returnConfig)}`);
+  return returnConfig;
+}
+
+module.exports = {
+  getAuthFromSecretConfig,
+  authTypes,
+};


### PR DESCRIPTION
This PR incorporates the secret service into the SFTP component. Users can now attach a credentials ID to the flow to utilize a secret. It is also backwards compatible with flows currently using explicit username and passwords/API keys. 